### PR TITLE
Default options to empty object

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -22,6 +22,8 @@ Db.prototype.close = function () {
 Db.prototype.collection = function(name, options, force) {
     if (!name)
         throw new Error('No name argument');
+
+    options = options || {};
     if (force)
         return new Collection(this._db, name, options);
     if (this._collections[name])
@@ -36,6 +38,7 @@ Db.prototype.admin = function () {
 
 Db.prototype.collectionNames = function (collectionName, options) {
     var resolver = Promise.defer();
+    options = options || {};
     this._db.collectionNames(collectionName, options, function(err, docs) {
         if (err)
             return resolver.reject(err);
@@ -56,6 +59,7 @@ Db.prototype.collections = function () {
 
 Db.prototype.eval = function (code, parameters, options) {
     var resolver = Promise.defer();
+    options = options || {};
     this._db.eval(code, parameters, options,function(err, docs) {
         if (err)
             return resolver.reject(err);
@@ -76,6 +80,7 @@ Db.prototype.logout = function () {
 
 Db.prototype.authenticate = function (username, password, options) {
     var resolver = Promise.defer();
+    options = options || {};
     this._db.authenticate(username, password, options, function(err, docs) {
         if (err)
             return resolver.reject(err);
@@ -86,6 +91,7 @@ Db.prototype.authenticate = function (username, password, options) {
 
 Db.prototype.addUser = function (username, password, options) {
     var resolver = Promise.defer();
+    options = options || {};
     this._db.addUser(username, password, options, function(err, docs) {
         if (err)
             return resolver.reject(err);
@@ -96,6 +102,7 @@ Db.prototype.addUser = function (username, password, options) {
 
 Db.prototype.removeUser = function (username, options) {
     var resolver = Promise.defer();
+    options = options || {};
     this._db.removeUser(username, options, function(err, docs) {
         if (err)
             return resolver.reject(err);
@@ -106,6 +113,7 @@ Db.prototype.removeUser = function (username, options) {
 
 Db.prototype.createCollection = function (collectionName, options) {
     var resolver = Promise.defer();
+    options = options || {};
     this._db.createCollection(collectionName, options, function(err, docs) {
         if (err)
             return resolver.reject(err);
@@ -126,6 +134,7 @@ Db.prototype.dropCollection = function (collectionName) {
 
 Db.prototype.renameCollection = function (fromCollection, toCollection, options) {
     var resolver = Promise.defer();
+    options = options || {};
     this._db.renameCollection(fromCollection, toCollection, options, function(err, docs) {
         if (err)
             return resolver.reject(err);
@@ -146,6 +155,7 @@ Db.prototype.dropDatabase = function () {
 
 Db.prototype.stats = function (options) {
     var resolver = Promise.defer();
+    options = options || {};
     this._db.stats(options, function(err, docs) {
         if (err)
             return resolver.reject(err);


### PR DESCRIPTION
Problem:
Mongo native driver often assumes the options will be an object or
a function (the callback), so it never takes into account an undefined
value for options.

Fix:
- set options to be either a valid passed in options or empty object

Note: I just fixed up the db lib because I wasn't sure about possible
breakage in the other files (I only needed the fix in the authenticate
method)