### PR TITLE
Expose raw mongo lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ var users = db.collection('users', {
 
 ## API
 
+###Top Level
+* `mongodb` - raw mongodb driver
+
 ###Collection
 [MongoDB Collection](http://mongodb.github.io/node-mongodb-native/api-generated/collection.html)
 [MongoDB Queries](http://mongodb.github.io/node-mongodb-native/markdown-docs/queries.html)

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,4 +25,7 @@ app.prototype.connect = function(url) {
     return resolver.promise;
 };
 
+//Expose raw driver
+app.prototype.mongodb = mongodb;
+
 module.exports = new app();


### PR DESCRIPTION
Expose the mongodb lib on mongodb-bluebird object for use of raw driver special objects such as mongodb.Long, mongodb.ObjectId, etc...